### PR TITLE
Fix exit 141 (SIGPIPE) in prerequisite checks

### DIFF
--- a/scripts/check-prerequisites.sh
+++ b/scripts/check-prerequisites.sh
@@ -17,13 +17,13 @@ check_command() {
   if command -v "$cmd" >/dev/null 2>&1; then
     local version
     if [ "$cmd" = "kubectl" ]; then
-      version=$("$cmd" version --client 2>&1 | head -1)
+      version=$("$cmd" version --client 2>&1 | head -1 || true)
     elif [ "$cmd" = "az" ]; then
       version="Azure CLI $(az version 2>&1 | jq -r '.["azure-cli"]' 2>/dev/null || echo 'unknown')"
     elif [ "$cmd" = "kubelogin" ]; then
       version=$("$cmd" --version 2>&1 | grep "git hash" | sed 's/git hash: //' | cut -d'/' -f1 || echo 'unknown')
     else
-      version=$("$cmd" --version 2>&1 | head -1)
+      version=$("$cmd" --version 2>&1 | head -1 || true)
     fi
     echo "  [OK] $name ($version)"
   else
@@ -41,7 +41,7 @@ check_command "git" "git" "https://git-scm.com/downloads"
 
 # Terraform version check
 if command -v terraform >/dev/null 2>&1; then
-  TF_VERSION=$(terraform version -json 2>/dev/null | jq -r '.terraform_version' 2>/dev/null || terraform version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+  TF_VERSION=$(terraform version -json 2>/dev/null | jq -r '.terraform_version' 2>/dev/null || { terraform version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true; })
   TF_MAJOR=$(echo "$TF_VERSION" | cut -d. -f1)
   TF_MINOR=$(echo "$TF_VERSION" | cut -d. -f2)
   if [ "$TF_MAJOR" -lt 1 ] || ([ "$TF_MAJOR" -eq 1 ] && [ "$TF_MINOR" -lt 11 ]); then


### PR DESCRIPTION
## Problem
`make create-cluster-gcp` (and the AWS/Azure equivalents) intermittently aborted at the prerequisite step with **exit code 141**, printing only the first tool check before dying:

```
  [OK] Terraform (>= 1.11.0) (Terraform v1.15.8)
$ echo $?
141
```

## Root cause
`scripts/check-prerequisites.sh` runs under `set -euo pipefail`. The version probes pipe a tool's output into `head -1`:

```sh
version=$("$cmd" --version 2>&1 | head -1)
```

`head -1` closes the pipe after the first line; the tool (`make`, `kubectl`, …) keeps writing, receives **SIGPIPE**, and exits 141. `pipefail` propagates that 141 as the pipeline's status, and `set -e` turns it into a full script abort. It's racy (depends on whether the tool's output fits the pipe buffer before `head` closes), which is why it looked intermittent — `terraform`/`jq`/`git` usually slipped through while `make`/`kubectl` did not.

## Fix
Guard the affected pipelines with `|| true` so a SIGPIPE from a version probe no longer aborts the check. `head`/`grep` have already captured the value before the writer is signalled, so displayed versions are unchanged. Covers:
- the `kubectl` and generic `--version | head -1` probes
- the `terraform version | head -1 | grep` fallback (only hit when the `-json` parse path fails)

## Verification
```
$ bash scripts/check-prerequisites.sh google   # → exit 0, "All prerequisites met!"
$ bash scripts/check-prerequisites.sh aws       # → exit 1 (missing tools/auth), graceful
$ bash scripts/check-prerequisites.sh azure     # → exit 1 (missing tools/auth), graceful
```
No path exits 141 any more; missing tools/auth still fail cleanly with exit 1. The Terraform fallback path was exercised directly and returns the version with exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)